### PR TITLE
Correct title tag in RSS link

### DIFF
--- a/layout/_partial/head.jade
+++ b/layout/_partial/head.jade
@@ -15,7 +15,7 @@ title
 
 link(href=config.root + 'favicon.png', rel='icon')
 
-link(rel='alternate', href=theme.rss ? theme.rss : config.root + 'atom.xml', title='config.title', type='application/atom.xml')
+link(rel='alternate', href=theme.rss ? theme.rss : config.root + 'atom.xml', title=config.title, type='application/atom.xml')
 
 link(href='http://fonts.googleapis.com/css?family=Open+Sans:400', rel='stylesheet')
 link(href='http://fonts.googleapis.com/css?family=Source+Code+Pro:400,600', rel='stylesheet', type='text/css')


### PR DESCRIPTION
Two wild apostrophes appeared at the title tag of the RSS link.
